### PR TITLE
feat: implementacion de POST /progress

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from app.routes.clients import router as clients_router
 from app.routes.routines import router as routines_router
+from app.routes.progress import router as progress_router
 
 app = FastAPI()
 
@@ -14,3 +15,4 @@ def health():
 
 app.include_router(clients_router)
 app.include_router(routines_router)
+app.include_router(progress_router)

--- a/app/routes/progress.py
+++ b/app/routes/progress.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter
+from app.utils import read_json, write_json
+from pydantic import BaseModel
+
+router = APIRouter(
+    prefix="/progress",
+    tags=["progress"]
+)
+
+
+class Progress(BaseModel):
+    client_id: int
+    note: str
+
+
+@router.post("/")
+def create_progress(progress: Progress):
+    all_progress = read_json("app/data/progress.json")
+
+    new_entry = {
+        "id": len(all_progress) + 1,
+        "client_id": progress.client_id,
+        "note": progress.note
+    }
+
+    all_progress.append(new_entry)
+    write_json("app/data/progress.json", all_progress)
+
+    return {
+        "message": "Progress registered successfully",
+        "progress": new_entry
+    }


### PR DESCRIPTION
Se implementó el endpoint `POST /progress` que permite registrar el progreso de un cliente.

## Cambios realizados

- Modelo `Progress` con validación de datos via Pydantic
- Generación automática de IDs
- Escritura en `progress.json` mediante `write_json`
- Registro del router en `app/main.py`

## Resultado

El progreso de los clientes puede registrarse correctamente mediante solicitudes POST.

Closes #6